### PR TITLE
feat(lib): add helper to generate overlays from channel and package list

### DIFF
--- a/lib/common.nix
+++ b/lib/common.nix
@@ -13,7 +13,12 @@ let
     substring
     ;
 
-  inherit (lib) flatten hasAttrByPath unique;
+  inherit (lib)
+    flatten
+    hasAttrByPath
+    splitString
+    unique
+    ;
 
 in
 {
@@ -49,4 +54,6 @@ in
       found = filter cb list;
     in
     if (length found) > 0 then head found else null;
+
+  generateAttrPath = base: string: foldl' (acc: cur: acc.${cur}) base (splitString "." string);
 }


### PR DESCRIPTION
Example usage:

```nix
{ icedosLib, ... }:
{
  nixpkgs.overlays = icedosLib.generatePackageOverlaysFromChannel "master" [ "python3Packages.transformers" ];
}
```

Above snippet will fetch `python3Packages.transformers` from master instead of the default pkgs channel (in our case unstable or chaotic, depending on the repos and modules loaded).