### PR TITLE
feat(patchable-flake-inputs): introduce support for patches for the final flake

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -99,11 +99,11 @@ if [[ "$update_core" == "1" && -z "$skip_update_core" ]]; then
 fi
 
 # Generate flake inputs
-export ICEDOS_FLAKE_INPUTS="$(ICEDOS_UPDATE="$update_repos" ICEDOS_STAGE="genflake" nix eval $refresh $trace --file "$ICEDOS_ROOT/lib/genflake.nix" flakeInputs | nixfmt | sed "1,1d" | sed "\$d")"
+ICEDOS_FLAKE_INPUTS_JSON="$(ICEDOS_UPDATE="$update_repos" ICEDOS_STAGE="genflake" nix build $refresh $trace --no-link --print-out-paths --file "$ICEDOS_ROOT/lib/genflake.nix" flakeInputsJson)"
+export ICEDOS_FLAKE_INPUTS="$(cat $ICEDOS_FLAKE_INPUTS_JSON | json2nix | sed "1,1d" | sed "\$d")"
 if [[ "${ICEDOS_FLAKE_INPUTS}" == "" ]]; then
   exit 1
 fi
-
 echo "{ inputs = { $ICEDOS_FLAKE_INPUTS }; outputs = { ... }: { }; }" >"$ICEDOS_STATE_DIR/$FLAKE"
 (
   set -e

--- a/build.sh
+++ b/build.sh
@@ -99,11 +99,11 @@ if [[ "$update_core" == "1" && -z "$skip_update_core" ]]; then
 fi
 
 # Generate flake inputs
-ICEDOS_FLAKE_INPUTS_JSON="$(ICEDOS_UPDATE="$update_repos" ICEDOS_STAGE="genflake" nix build $refresh $trace --no-link --print-out-paths --file "$ICEDOS_ROOT/lib/genflake.nix" flakeInputsJson)"
-export ICEDOS_FLAKE_INPUTS="$(cat $ICEDOS_FLAKE_INPUTS_JSON | json2nix | sed "1,1d" | sed "\$d")"
+export ICEDOS_FLAKE_INPUTS="$(ICEDOS_UPDATE="$update_repos" ICEDOS_STAGE="genflake" nix eval $refresh $trace --raw --file "$ICEDOS_ROOT/lib/genflake.nix" flakeInputsNix | nixfmt | sed "1,1d" | sed "\$d")"
 if [[ "${ICEDOS_FLAKE_INPUTS}" == "" ]]; then
   exit 1
 fi
+
 echo "{ inputs = { $ICEDOS_FLAKE_INPUTS }; outputs = { ... }: { }; }" >"$ICEDOS_STATE_DIR/$FLAKE"
 (
   set -e

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,15 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    json2nix = {
+      url = "github:cloudandheat/json2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
   outputs =
     {
+      json2nix,
       nixpkgs,
       self,
       ...
@@ -62,6 +67,7 @@
                   nixfmt
                   rsync
                   toml2json
+                  (json2nix.packages.${system}.default)
                 ]
               }:$PATH"
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,15 +1,10 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    json2nix = {
-      url = "github:cloudandheat/json2nix";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =
     {
-      json2nix,
       nixpkgs,
       self,
       ...
@@ -67,7 +62,6 @@
                   nixfmt
                   rsync
                   toml2json
-                  (json2nix.packages.${system}.default)
                 ]
               }:$PATH"
 

--- a/lib/genflake.nix
+++ b/lib/genflake.nix
@@ -4,7 +4,7 @@ let
 
   system = icedos.system.arch or "x86_64-linux";
   pkgs = import <nixpkgs> { inherit system; };
-  inherit (pkgs) lib;
+  inherit (pkgs) lib writeText;
 
   inherit (lib)
     all
@@ -157,7 +157,9 @@ let
       }).config;
 in
 {
-  inherit flakeInputs evaluatedConfig;
+  inherit evaluatedConfig;
+
+  flakeInputsJson = flakeInputs |> toJSON |> writeText "inputs.json";
 
   flakeFinal = ''
     {

--- a/lib/genflake.nix
+++ b/lib/genflake.nix
@@ -14,6 +14,7 @@ let
     evalModules
     fileContents
     filter
+    generators
     imap0
     listToAttrs
     optional
@@ -159,7 +160,10 @@ in
 {
   inherit evaluatedConfig;
 
-  flakeInputsJson = flakeInputs |> toJSON |> writeText "inputs.json";
+  flakeInputsNix = generators.toPretty {
+    multiline = true;
+    allowPrettyValues = true;
+  } flakeInputs;
 
   flakeFinal = ''
     {

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -8,8 +8,10 @@
 let
   inherit (builtins)
     attrNames
+    fromJSON
     listToAttrs
     pathExists
+    readFile
     replaceStrings
     ;
 
@@ -28,6 +30,7 @@ let
     flatten
     genList
     hasAttr
+    hasAttrByPath
     mapAttrs
     mapAttrsToList
     max
@@ -35,7 +38,12 @@ let
     sort
     ;
 
-  inherit (icedosLib) stringStartsWith;
+  inherit (icedosLib)
+    ICEDOS_STAGE
+    ICEDOS_STATE_DIR
+    INPUTS_PREFIX
+    stringStartsWith
+    ;
 
 in
 rec {
@@ -390,6 +398,23 @@ rec {
         value ? { },
       }:
       mapAttrs (_: _: value) (filterAttrs (_: v: v.isNormalUser) users);
+
+    mkGroupInjector = group: users: mapAttrs (_: _: { extraGroups = [ group ]; }) users;
+  };
+
+  color = {
+    hexToRgbInts =
+      hex:
+      let
+        inherit (lib) fromHexString removePrefix;
+        inherit (builtins) substring;
+        h = removePrefix "#" hex;
+      in
+      [
+        (fromHexString (substring 0 2 h))
+        (fromHexString (substring 2 2 h))
+        (fromHexString (substring 4 2 h))
+      ];
   };
 
   desktop = {
@@ -536,4 +561,85 @@ rec {
         ) directoriesPaths
       )
     );
+
+  # ─── flake / input helpers ────────────────────────────────────────────────
+  # Consumed by lib/genflake.nix and lib/icedos.nix.
+
+  # Build a flake-input name from arbitrary identifying parts. Joins with
+  # `-`, prefixes with `INPUTS_PREFIX`, and replaces flake-URL-unsafe
+  # characters (`:`, `/`, `.`, `?`, `=`) with `_` so the result is a valid
+  # flake registry name. Used for module submodule inputs (parts: [ url ] or
+  # [ url subMod ]) and for url-mode overlay inputs (parts: [ "overlay" url ]).
+  mkInputName =
+    { parts }:
+    replaceStrings [ ":" "/" "." "?" "=" ] [ "_" "_" "_" "_" "_" ] (
+      concatStringsSep "-" ([ INPUTS_PREFIX ] ++ parts)
+    );
+
+  inputIsOverride = { input }: (hasAttr "override" input) && input.override;
+  inputHasPatches = { input }: (hasAttr "patches" input) && builtins.length input.patches > 0;
+
+  # Read the state flake.lock — the only lock that holds entries for the
+  # dynamically-generated repo inputs. Returns null on first build (lock
+  # absent) so callers can treat it as "no pin available".
+  _readFlakeLock =
+    let
+      lockPath = "${ICEDOS_STATE_DIR}/flake.lock";
+    in
+    if pathExists lockPath then fromJSON (readFile lockPath) else null;
+
+  # Determine the revision suffix from flake.lock based on repo name.
+  # Returns either /{rev}, ?narHash={hash}, or empty string.
+  _getRevisionFromLock =
+    {
+      repoName,
+      lock,
+    }:
+    let
+      hasRev = hasAttrByPath [ "nodes" repoName "locked" "rev" ] lock;
+      hasNarHash = hasAttrByPath [ "nodes" repoName "locked" "narHash" ] lock;
+    in
+    if (builtins.getEnv "ICEDOS_UPDATE" == "1") || (!hasRev && !hasNarHash) then
+      ""
+    else if hasRev then
+      "/${lock.nodes.${repoName}.locked.rev}"
+    else
+      "?narHash=${lock.nodes.${repoName}.locked.narHash}";
+
+  # Get the flake revision string (with / or ? prefix if available).
+  _resolveFlakeRevision =
+    {
+      url,
+      repoName,
+    }:
+    let
+      lock = _readFlakeLock;
+    in
+    if (lock == null) || ((stringStartsWith "path:" url) && (ICEDOS_STAGE == "genflake")) then
+      ""
+    else
+      _getRevisionFromLock { inherit repoName lock; };
+
+  # Split a flake URL of the form `scheme:owner/repo/<ref>` into
+  # { baseUrl = "scheme:owner/repo"; ref = "<ref>"; }. Only applies to schemes
+  # that encode the ref as the third path segment (github, gitlab, sourcehut).
+  # For any other URL shape returns the URL unchanged and ref = null.
+  _parseFlakeUrl =
+    url:
+    let
+      match = builtins.match "(github|gitlab|sourcehut):([^/?]+)/([^/?]+)/([^?]+)(.*)" url;
+    in
+    if match == null then
+      {
+        baseUrl = url;
+        ref = null;
+      }
+    else
+      {
+        baseUrl = "${builtins.elemAt match 0}:${builtins.elemAt match 1}/${builtins.elemAt match 2}${builtins.elemAt match 4}";
+        ref = builtins.elemAt match 3;
+      };
+
+  # Generate a unique key for a module (url/name combination).
+  _getModuleKey = url: name: "${url}/${name}";
 }

--- a/lib/icedos.nix
+++ b/lib/icedos.nix
@@ -3,12 +3,14 @@
   icedosLib,
   inputs,
   lib,
+  pkgs,
   ...
 }:
 
 let
   inherit (builtins)
     hasAttr
+    length
     pathExists
     readFile
     replaceStrings
@@ -35,6 +37,7 @@ let
 
   finalIcedosLib = icedosLib // rec {
     inputIsOverride = { input }: (hasAttr "override" input) && input.override;
+    inputHasPatches = { input }: (hasAttr "patches" input) && length input.patches > 0;
 
     # Build a flake-input name from arbitrary identifying parts. Joins with
     # `-`, prefixes with `INPUTS_PREFIX`, and replaces flake-URL-unsafe
@@ -200,7 +203,8 @@ let
     _getModuleInputs =
       modules:
       let
-        inherit (builtins) attrNames filter;
+        inherit (builtins) attrNames filter getFlake;
+        inherit (pkgs) applyPatches;
         modulesWithInputs = filter (hasAttr "inputs") modules;
       in
       flatten (
@@ -215,6 +219,8 @@ let
             i:
             let
               isOverride = inputIsOverride { input = inputs.${i}; };
+              hasPatches = inputHasPatches { input = inputs.${i}; };
+
               moduleIdentifier =
                 if (hasAttr "skipModuleAsInput" _repoInfo && _repoInfo.skipModuleAsInput) then
                   "icedos-config"
@@ -225,12 +231,42 @@ let
                       meta.name
                     ];
                   };
+
+              patchedInputSource = applyPatches {
+                name = "${i}-patched";
+                patches = inputs.${i}.patches;
+                src = getFlake inputs.${i}.url |> toString;
+              };
+
+              normalInput = rec {
+                _originalName = if hasPatches then "${i}_source" else i;
+                name = if isOverride then _originalName else "${moduleIdentifier}-${_originalName}";
+                value = removeAttrs inputs.${i} [
+                  "override"
+                  "patches"
+                ];
+              };
+
+              patchedInput = rec {
+                _originalName = i;
+                name = if isOverride then _originalName else "${moduleIdentifier}-${_originalName}";
+                value =
+                  (removeAttrs inputs.${i} [
+                    "override"
+                    "patches"
+                  ])
+                  // {
+                    url = "path:${patchedInputSource}";
+                  };
+              };
             in
-            {
-              _originalName = i;
-              name = if isOverride then i else "${moduleIdentifier}-${i}";
-              value = removeAttrs inputs.${i} [ "override" ];
-            }
+            if hasPatches then
+              [
+                normalInput
+                patchedInput
+              ]
+            else
+              normalInput
           ) (attrNames inputs)
         ) modulesWithInputs
       );

--- a/lib/icedos.nix
+++ b/lib/icedos.nix
@@ -10,109 +10,30 @@
 let
   inherit (builtins)
     hasAttr
-    length
     pathExists
-    readFile
-    replaceStrings
     ;
 
   inherit (lib)
-    concatStringsSep
     elem
     filter
     flatten
-    hasAttrByPath
     ;
 
   inherit (icedosLib)
     ICEDOS_CONFIG_ROOT
     ICEDOS_STAGE
-    ICEDOS_STATE_DIR
-    INPUTS_PREFIX
+    _getModuleKey
+    _parseFlakeUrl
+    _resolveFlakeRevision
     filterByAttrs
     findFirst
     flatMap
-    stringStartsWith
+    inputHasPatches
+    inputIsOverride
+    mkInputName
     ;
 
   finalIcedosLib = icedosLib // rec {
-    inputIsOverride = { input }: (hasAttr "override" input) && input.override;
-    inputHasPatches = { input }: (hasAttr "patches" input) && length input.patches > 0;
-
-    # Build a flake-input name from arbitrary identifying parts. Joins with
-    # `-`, prefixes with `INPUTS_PREFIX`, and replaces flake-URL-unsafe
-    # characters (`:`, `/`, `.`, `?`, `=`) with `_` so the result is a valid
-    # flake registry name. Used for module submodule inputs (parts: [ url ] or
-    # [ url subMod ]) and for url-mode overlay inputs (parts: [ "overlay" url ]).
-    mkInputName =
-      { parts }:
-      replaceStrings [ ":" "/" "." "?" "=" ] [ "_" "_" "_" "_" "_" ] (
-        concatStringsSep "-" ([ INPUTS_PREFIX ] ++ parts)
-      );
-
-    # Read the state flake.lock — the only lock that holds entries for the
-    # dynamically-generated repo inputs. Returns null on first build (lock
-    # absent) so callers can treat it as "no pin available".
-    _readFlakeLock =
-      let
-        lockPath = "${ICEDOS_STATE_DIR}/flake.lock";
-      in
-      if pathExists lockPath then readFile lockPath |> builtins.fromJSON else null;
-
-    # Determine the revision suffix from flake.lock based on repo name
-    # Returns either /{rev}, ?narHash={hash}, or empty string
-    _getRevisionFromLock =
-      {
-        repoName,
-        lock,
-      }:
-      let
-        hasRev = hasAttrByPath [ "nodes" repoName "locked" "rev" ] lock;
-        hasNarHash = hasAttrByPath [ "nodes" repoName "locked" "narHash" ] lock;
-      in
-      if (builtins.getEnv "ICEDOS_UPDATE" == "1") || (!hasRev && !hasNarHash) then
-        ""
-      else if hasRev then
-        "/${lock.nodes.${repoName}.locked.rev}"
-      else
-        "?narHash=${lock.nodes.${repoName}.locked.narHash}";
-
-    # Get the flake revision string (with / or ? prefix if available)
-    _resolveFlakeRevision =
-      {
-        url,
-        repoName,
-      }:
-      let
-        lock = _readFlakeLock;
-      in
-      if (lock == null) || ((stringStartsWith "path:" url) && (ICEDOS_STAGE == "genflake")) then
-        ""
-      else
-        _getRevisionFromLock {
-          inherit repoName lock;
-        };
-
-    # Split a flake URL of the form `scheme:owner/repo/<ref>` into
-    # { baseUrl = "scheme:owner/repo"; ref = "<ref>"; }. Only applies to schemes
-    # that encode the ref as the third path segment (github, gitlab, sourcehut).
-    # For any other URL shape returns the URL unchanged and ref = null.
-    _parseFlakeUrl =
-      url:
-      let
-        match = builtins.match "(github|gitlab|sourcehut):([^/?]+)/([^/?]+)/([^?]+)(.*)" url;
-      in
-      if match == null then
-        {
-          baseUrl = url;
-          ref = null;
-        }
-      else
-        {
-          baseUrl = "${builtins.elemAt match 0}:${builtins.elemAt match 1}/${builtins.elemAt match 2}${builtins.elemAt match 4}";
-          ref = builtins.elemAt match 3;
-        };
-
     # Fetch a modules repository, resolving the URL and loading its icedos modules
     # Handles overrides, flake resolution, and module file loading
     fetchModulesRepository =
@@ -232,12 +153,6 @@ let
                     ];
                   };
 
-              patchedInputSource = applyPatches {
-                name = "${i}-patched";
-                patches = inputs.${i}.patches;
-                src = getFlake inputs.${i}.url |> toString;
-              };
-
               normalInput = rec {
                 _originalName = if hasPatches then "${i}_source" else i;
                 name = if isOverride then _originalName else "${moduleIdentifier}-${_originalName}";
@@ -245,6 +160,32 @@ let
                   "override"
                   "patches"
                 ];
+              };
+
+              # Resolve the upstream URL against the state lock so the patched
+              # derivation's `src` matches the rev pinned in flake.lock under
+              # `normalInput.name`. Mirrors fetchModulesRepository's contract.
+              _patchSrcParsed = _parseFlakeUrl inputs.${i}.url;
+
+              _patchSrcLockRev = _resolveFlakeRevision {
+                url = _patchSrcParsed.baseUrl;
+                repoName = normalInput.name;
+              };
+
+              _patchSrcRev =
+                if _patchSrcLockRev != "" then
+                  _patchSrcLockRev
+                else if _patchSrcParsed.ref != null then
+                  "/${_patchSrcParsed.ref}"
+                else
+                  "";
+
+              _patchSrcUrl = "${_patchSrcParsed.baseUrl}${_patchSrcRev}";
+
+              patchedInputSource = applyPatches {
+                name = "${moduleIdentifier}-${i}-patched";
+                patches = inputs.${i}.patches;
+                src = getFlake _patchSrcUrl |> toString;
               };
 
               patchedInput = rec {
@@ -372,9 +313,6 @@ let
           options
           ;
       };
-
-    # Generate a unique key for a module (url/name combination)
-    _getModuleKey = url: name: "${url}/${name}";
 
     # Build a set of override URL mappings from dependencies that define overrides
     _buildOverridesMap =


### PR DESCRIPTION
This PR adds support for `patches` field under inputs.

In the following example, I am changing aagl's Flake behavior to install asciiquarium to my system, instead of returning its normal modules

```nix
{
  inputs.aagl = {
    url = "github:ezKEa/aagl-gtk-on-nix";
    inputs.nixpkgs.follows = "nixpkgs";
    patches = [ ./aagl.patch ];
  };
}
```

> `aagl.patch`
```diff
diff --git a/flake.nix b/flake.nix
--- flake.nix
+++ flake.nix
@@ -37,11 +37,10 @@
     inherit nixConfig;
 
     overlays.default = (import ./overlay.nix) { inherit rust-overlay; };
 
-    nixosModules.default = {
-      imports = [ ./module ];
-      nixpkgs.overlays = [ self.overlays.default ];
+    nixosModules.default = { pkgs, ... }: {
+      environment.systemPackages = [ pkgs.asciiquarium ];
     };
 
     packages = genSystems pkgsFor;
   };
```

TODO:

- [ ] use the locked version of the input when calling `getFlake` for patching
