### PR TITLE
fix(build): do not fail without git and pass nix config to nixos-rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To get started with the default [template](https://github.com/IceDOS/template), 
 ```bash
 git clone https://github.com/icedos/template icedos
 cd icedos
-nix --extra-experimental-features "flakes nix-command pipe-operators" run . -- --boot
+nix --extra-experimental-features "flakes nix-command pipe-operators" run path:. -- --boot
 ```
 
 ## ⚙️ Configuration

--- a/build.sh
+++ b/build.sh
@@ -94,7 +94,7 @@ fi
 if [[ "$update_core" == "1" && -z "$skip_update_core" ]]; then
   cd "$ICEDOS_CONFIG_ROOT"
   nix flake update
-  exec env skip_update_core=1 nix run . -- "${previous_arguments[@]}"
+  exec env skip_update_core=1 nix run path:. -- "${previous_arguments[@]}"
   exit 0
 fi
 
@@ -154,7 +154,7 @@ cd $ICEDOS_BUILD_DIR
 
 # Build the system configuration
 if (( ${#nixBuildArgs[@]} != 0 )); then
-  sudo nixos-rebuild $action --flake .#"$(cat /etc/hostname)" --no-update-lock-file $trace "${nixBuildArgs[@]}" "${globalBuildArgs[@]}"
+  sudo --preserve-env=NIX_CONFIG nixos-rebuild $action --flake .#"$(cat /etc/hostname)" --no-update-lock-file $trace "${nixBuildArgs[@]}" "${globalBuildArgs[@]}"
   exit 0
 fi
 

--- a/flake.nix
+++ b/flake.nix
@@ -74,7 +74,7 @@
               echo "#!/usr/bin/env bash" >>"$ICEDOS_STATE_DIR/build.sh"
               echo "set -e" >>"$ICEDOS_STATE_DIR/build.sh"
               echo "cd \"$PWD\"" >>"$ICEDOS_STATE_DIR/build.sh"
-              echo "nix run . -- \"\$@\"" >>"$ICEDOS_STATE_DIR/build.sh"
+              echo "nix run path:. -- \"\$@\"" >>"$ICEDOS_STATE_DIR/build.sh"
 
               bash "${self}/build.sh" "$@"
             ''


### PR DESCRIPTION
Fixes two issues:

- Missing git, breaking first install build
- First install build failing with --builder, because sudo dropped our nix config env