### PR TITLE
rework(build): add performance improvements and --run-vm flag

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -32,6 +32,11 @@ while [[ $# -gt 0 ]]; do
       action="build-vm"
       shift
       ;;
+    --run-vm)
+      action="build-vm"
+      run_vm=1
+      shift
+      ;;
     --export-full-config)
       export_full_config=1
       shift
@@ -82,10 +87,14 @@ done
 
 export NIX_CONFIG="experimental-features = flakes nix-command pipe-operators"
 
-mkdir -p "$ICEDOS_DIR"
+if [[ "$update_core" == "1" && -z "$skip_update_core" ]]; then
+  cd "$ICEDOS_CONFIG_ROOT"
+  nix flake update --refresh
+  exec env skip_update_core=1 nix run path:. -- "${previous_arguments[@]}"
+  exit 0
+fi
 
-export ICEDOS_BUILD_DIR="$(mktemp -d -t icedos-build-XXXXXXX-0)"
-mkdir -p "$ICEDOS_BUILD_DIR"
+mkdir -p "$ICEDOS_DIR"
 
 # Save current directory into a file
 [ -f "$CONFIG" ] && rm -f "$CONFIG" || sudo rm -rf "$CONFIG"
@@ -95,31 +104,26 @@ if [ "$update_repos" == "1" ]; then
   refresh="--refresh"
 fi
 
-if [[ "$update_core" == "1" && -z "$skip_update_core" ]]; then
-  cd "$ICEDOS_CONFIG_ROOT"
-  nix flake update
-  exec env skip_update_core=1 nix run path:. -- "${previous_arguments[@]}"
-  exit 0
-fi
+export ICEDOS_BUILD_DIR="$(mktemp -d -t icedos-build-XXXXXXX-0)"
+mkdir -p "$ICEDOS_BUILD_DIR"
 
-# Generate flake inputs
-export ICEDOS_FLAKE_INPUTS="$(ICEDOS_UPDATE="$update_repos" ICEDOS_STAGE="genflake" nix eval $refresh $trace --raw --file "$ICEDOS_ROOT/lib/genflake.nix" flakeInputsNix | nixfmt | sed "1,1d" | sed "\$d")"
-if [[ "${ICEDOS_FLAKE_INPUTS}" == "" ]]; then
-  exit 1
-fi
+# Generate flake
+ICEDOS_UPDATE="$update_repos" ICEDOS_STAGE="genflake" nix eval $refresh $trace --file "$ICEDOS_ROOT/lib/genflake.nix" --raw flakeFinal >"$ICEDOS_STATE_DIR/$FLAKE"
+nixfmt "$ICEDOS_STATE_DIR/$FLAKE"
 
-echo "{ inputs = { $ICEDOS_FLAKE_INPUTS }; outputs = { ... }: { }; }" >"$ICEDOS_STATE_DIR/$FLAKE"
 (
   set -e
   cd "$ICEDOS_STATE_DIR"
-  nix flake prefetch-inputs
+
+  if [ ! -f flake.lock ] || [ -n "$update_core$update_nixpkgs$update_repos" ]; then
+    nix flake prefetch-inputs
+  fi
+
   nix flake update icedos-config 2>/dev/null || true
   nix flake update icedos-state 2>/dev/null || true
-)
 
-# Generate flake
-ICEDOS_STAGE="genflake" nix eval $trace --file "$ICEDOS_ROOT/lib/genflake.nix" --raw flakeFinal >"$ICEDOS_STATE_DIR/$FLAKE"
-nixfmt "$ICEDOS_STATE_DIR/$FLAKE"
+  [ "$update_core" == "1" ] && nix flake update icedos-core --refresh 2>/dev/null || true
+)
 
 if [ "$export_full_config" == "1" ]; then
   (
@@ -140,27 +144,22 @@ fi
   nix flake update nixpkgs
 )
 
-rsync -a "$ICEDOS_CONFIG_ROOT" "$ICEDOS_BUILD_DIR" \
---exclude='.editorconfig' \
---exclude='.git' \
---exclude='.gitignore' \
---exclude='.state/.cache' \
---exclude='.taplo.toml' \
---exclude='LICENSE' \
---exclude='README.md' \
---exclude='flake.lock' \
---exclude='flake.nix'
-
-cp "$ICEDOS_STATE_DIR"/* "$ICEDOS_BUILD_DIR"
-
-echo "Building from path $ICEDOS_BUILD_DIR"
+rsync -a "$ICEDOS_STATE_DIR/" "$ICEDOS_BUILD_DIR"
+echo "building from path $ICEDOS_BUILD_DIR..."
 cd $ICEDOS_BUILD_DIR
 
 # Build the system configuration
 if [[ (( ${#nixBuildArgs[@]} != 0 )) || "$action" == "build-vm" ]]; then
   [ "$action" == "switch" ] && sudo="sudo --preserve-env=NIX_CONFIG"
 
-  $sudo nixos-rebuild $action --flake .#"$(cat /etc/hostname)" --no-update-lock-file $trace "${nixBuildArgs[@]}" "${globalBuildArgs[@]}"
+  CURRENT_HOSTNAME="$(cat /etc/hostname)"
+
+  $sudo nixos-rebuild $action --flake .#"$CURRENT_HOSTNAME" --no-update-lock-file $trace "${nixBuildArgs[@]}" "${globalBuildArgs[@]}"
+
+  if [ "$run_vm" == "1" ]; then
+    exec result/bin/run-"$CURRENT_HOSTNAME"-vm
+  fi
+
   exit 0
 fi
 

--- a/lib/genflake.nix
+++ b/lib/genflake.nix
@@ -30,7 +30,6 @@ let
 
   inherit (icedosLib)
     ICEDOS_CONFIG_ROOT
-    ICEDOS_FLAKE_INPUTS
     ICEDOS_STATE_DIR
     injectIfExists
     mkInputName
@@ -157,20 +156,18 @@ let
     }).config;
 
   evaluatedConfig = toJSON evaluated;
-in
-{
-  inherit evaluatedConfig;
 
   flakeInputsNix = generators.toPretty {
     multiline = true;
     allowPrettyValues = true;
   } flakeInputs;
+in
+{
+  inherit evaluatedConfig flakeInputsNix;
 
   flakeFinal = ''
     {
-      inputs = {
-        ${ICEDOS_FLAKE_INPUTS}
-      };
+      inputs = ${flakeInputsNix};
 
       outputs =
         {

--- a/lib/helpers.nix
+++ b/lib/helpers.nix
@@ -360,27 +360,106 @@ rec {
           ${concatMapStrings fileLeafComplete fileLeaves}'';
     };
 
-  generateAccentColor =
+  # Authoritative libadwaita named-accent → hex map. Mirrors GNOME 47+
+  # `org/gnome/desktop/interface.accent-color` enum and libadwaita's
+  # `_palette.scss`. Bare hex (no `#`) so callers can pick the form.
+  libadwaitaAccentHex = {
+    blue = "3584e4";
+    green = "3a944a";
+    orange = "ed5b00";
+    pink = "d56199";
+    purple = "9141ac";
+    red = "e62d42";
+    slate = "6f8396";
+    teal = "2190a4";
+    yellow = "c88800";
+  };
+
+  # Single source of truth for `icedos.desktop.accentColor` resolution.
+  # Accepts a libadwaita name, a base16 slot (`base08`..`base0F`, only
+  # meaningful when stylix is on), or a hex (`RRGGBB` / `#RRGGBB`).
+  # Empty → "purple". Returns:
+  #   { hex; hexNoHash; name; slot; warning; gnomeOn; stylixOn; }
+  # `warning` is non-null when GNOME is on but the input is not a libadwaita
+  # named accent — `org/gnome/desktop/interface.accent-color` is a string
+  # enum, so a slot/hex input causes the GNOME shell to render a fallback
+  # name while libadwaita apps render the user's hex.
+  generateAccent =
+    config:
+    let
+      inherit (lib)
+        elem
+        hasAttr
+        removePrefix
+        toLower
+        ;
+
+      desktopCfg = config.icedos.desktop;
+      raw = desktopCfg.accentColor;
+
+      gnomeOn = hasAttr "gnome" desktopCfg;
+      stylixOn = config.stylix.enable or false;
+
+      namedAccents = attrNames libadwaitaAccentHex;
+
+      # base16 slot inverse — only used when input is a slot and we still
+      # need a libadwaita name (e.g. for the GNOME dconf write under stylix).
+      # Mirrors the bundled `adwaita` handler in
+      # desktop/modules/stylix/lib.nix.
+      defaultSlotToName = {
+        base08 = "red";
+        base09 = "orange";
+        base0A = "yellow";
+        base0B = "green";
+        base0C = "teal";
+        base0D = "blue";
+        base0E = "purple";
+        base0F = "slate";
+      };
+
+      isHex = s: builtins.match "#?[0-9a-fA-F]{6}" s != null;
+      isName = s: elem (toLower s) namedAccents;
+      isSlot = s: builtins.match "base0[89A-Fa-f]" s != null;
+
+      input = if raw == "" then "purple" else raw;
+
+      name =
+        if isName input then
+          toLower input
+        else if isSlot input then
+          defaultSlotToName.${input} or "blue"
+        else
+          "blue";
+
+      hexNoHash =
+        if isHex input then
+          removePrefix "#" input
+        else if isSlot input && stylixOn then
+          config.lib.stylix.colors.${input}
+        else
+          libadwaitaAccentHex.${name};
+
+      hex = "#${hexNoHash}";
+
+      slot = if isSlot input then input else null;
+
+      warning =
+        if gnomeOn && !(isName input) then
+          "icedos.desktop.accentColor: GNOME is enabled but `${input}` is not a libadwaita named accent. The GNOME shell will use `${name}`; libadwaita apps and other consumers will use `${hex}`. Set accentColor to one of ${concatStringsSep ", " namedAccents} to keep them in sync."
+        else
+          null;
+    in
     {
-      accentColor,
-      gnomeAccentColor,
-      hasGnome,
-    }:
-    if (!hasGnome) then
-      "#${accentColor}"
-    else
-      {
-        blue = "#3584e4";
-        green = "#3a944a";
-        orange = "#ed5b00";
-        pink = "#d56199";
-        purple = "#9141ac";
-        red = "#e62d42";
-        slate = "#6f8396";
-        teal = "#2190a4";
-        yellow = "#c88800";
-      }
-      .${gnomeAccentColor};
+      inherit
+        hex
+        hexNoHash
+        name
+        slot
+        warning
+        gnomeOn
+        stylixOn
+        ;
+    };
 
   users = {
     getNormal =
@@ -441,18 +520,9 @@ rec {
 
     # Returns the active accent color as a 6-char hex string (no `#`),
     # used by per-WM modules to colour focused-window borders /
-    # active-hint indicators. Prefers the Stylix-resolved colour (so it
-    # tracks the base16 palette), falls back to the icedos-level
-    # `desktop.accentColor`.
-    accentHex =
-      config:
-      let
-        inherit (config.icedos) desktop;
-        stylixCfg = desktop.stylix or { enable = false; };
-        stylixOn = stylixCfg.enable or false;
-        stylixSlot = stylixCfg.accentBase16Slot or "base0E";
-      in
-      if stylixOn then config.lib.stylix.colors.${stylixSlot} else desktop.accentColor;
+    # active-hint indicators. Wraps `generateAccent` so all consumers
+    # share the same name/slot/hex resolution rules.
+    accentHex = config: (generateAccent config).hexNoHash;
   };
 
   pkgs = rec {


### PR DESCRIPTION
#### Performance improvements:

- Makes `--update-core` first run minimal and computes everything on the second run, instead of computing on both runs.
- It unifies the two nix evals calculating inputs into one.
- useless rsync `ICEDOS_CONFIG_ROOT` -> `ICEDOS_BUILD_DIR` removed.
- cp replaced with rsync, no excludes required.

#### Features:

- `--run-vm`, which uses `build-vm` as the nixos-rebuild action and then executes the resulting nixos vm bin.